### PR TITLE
Add the MIT License to This Repo

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2022 EOS Network Foundation
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/backend/package.json
+++ b/backend/package.json
@@ -5,7 +5,7 @@
   "main": "index.js",
   "keywords": [],
   "author": "",
-  "license": "ISC",
+  "license": "MIT",
   "engineStrict": true,
   "engines": {
     "node": "16",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,7 @@
 {
   "name": "frontend",
   "version": "1.0.0",
+  "license": "MIT",
   "private": true,
   "engineStrict": true,
   "engines": {

--- a/structures/package.json
+++ b/structures/package.json
@@ -3,7 +3,7 @@
   "version": "1.0.0",
   "description": "",
   "author": "",
-  "license": "ISC",
+  "license": "MIT",
   "engineStrict": true,
   "engines": {
     "node": "16",


### PR DESCRIPTION
From devrel [issue 135](https://github.com/eosnetworkfoundation/devrel/issues/135), this pull request adds the MIT software license to this repo.

## See Also
- [Pull Request 1](https://github.com/eosnetworkfoundation/devhub/pull/1) - .gitignore Updates
- [Pull Request 2](https://github.com/eosnetworkfoundation/devhub/pull/2) - Pin nodeJS Toolchain
- [Pull Request 3](https://github.com/eosnetworkfoundation/devhub/pull/3) - Add the MIT License to This Repo
- [Pull Request 4](https://github.com/eosnetworkfoundation/devhub/pull/4) - package.json + README.md Updates
- [Pull Request 5](https://github.com/eosnetworkfoundation/devhub/pull/5) - Moar Documentation
- [Pull Request 6](https://github.com/eosnetworkfoundation/devhub/pull/6) - Rename BACKEND_API to DEVHUB_BACKEND_API in the Environment
- [Pull Request 7](https://github.com/eosnetworkfoundation/devhub/pull/7) - DevHub Frontend CICD Pipeline - Build Part 1
- [Pull Request 8](https://github.com/eosnetworkfoundation/devhub/pull/8) - DevHub Frontend CICD Pipeline - Build Part 2
- [Pull Request 9](https://github.com/eosnetworkfoundation/devhub/pull/9) - Authenticate to AWS Using OIDC in GitHub Actions
- [Pull Request 10](https://github.com/eosnetworkfoundation/devhub/pull/10) - Add Contextual AWS Deployment to GitHub Actions
- [Pull Request 11](https://github.com/eosnetworkfoundation/devhub/pull/11) - Fix Production AWS Deployment

