### PR TITLE
DevHub Frontend CICD Pipeline - Build Part 1

### DIFF
--- a/.github/workflows/frontend.sh
+++ b/.github/workflows/frontend.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+set -eo pipefail
+
+function ee()
+{
+    echo "$ $*"
+    eval "$@"
+}
+
+# print debugging code
+ee node --version
+ee yarn --version
+if [[ ! -z "$BACKEND_API" ]]; then
+    ee 'printf "$BACKEND_API" | wc -c'
+else
+    printf '\e[93mWARNING: BACKEND_API is not defined!\e[0m\n'
+fi
+# init
+ee pushd frontend
+ee yarn --frozen-lockfile
+# generate static site
+ee yarn generate
+# pack dist folder
+ee tar -cvf dist.tar.gz dist/*
+echo 'Done! - frontend.sh'

--- a/.github/workflows/frontend.sh
+++ b/.github/workflows/frontend.sh
@@ -10,10 +10,10 @@ function ee()
 # print debugging code
 ee node --version
 ee yarn --version
-if [[ ! -z "$BACKEND_API" ]]; then
-    ee 'printf "$BACKEND_API" | wc -c'
+if [[ ! -z "$DEVHUB_BACKEND_API" ]]; then
+    ee 'printf "$DEVHUB_BACKEND_API" | wc -c'
 else
-    printf '\e[93mWARNING: BACKEND_API is not defined!\e[0m\n'
+    printf '\e[93mWARNING: DEVHUB_BACKEND_API is not defined!\e[0m\n'
 fi
 # init
 ee pushd frontend

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -1,0 +1,25 @@
+name: DevHub Frontend CICD
+
+on: [push, pull_request]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: [16]
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Frontend Build - nodeJS v${{ matrix.node-version }}
+        uses: actions/setup-node@v3
+        with:
+          node-version: ${{ matrix.node-version }}
+        run: .github/workflows/frontend.sh
+
+      - uses: actions/upload-artifact@v3
+        with:
+          name: dist-node-${{ matrix.node-version }}
+          path: frontend/dist.tar.gz


### PR DESCRIPTION
From devrel [issue 135](https://github.com/eosnetworkfoundation/devrel/issues/135), this pull request contains the start of a CICD pipeline for the DevHub frontend. This code inits, builds, and uploads the frontend code. A subsequent pull request will publish the build to the website.

## See Also
- [Pull Request 1](https://github.com/eosnetworkfoundation/devhub/pull/1) - .gitignore Updates
- [Pull Request 2](https://github.com/eosnetworkfoundation/devhub/pull/2) - Pin nodeJS Toolchain
- [Pull Request 3](https://github.com/eosnetworkfoundation/devhub/pull/3) - Add the MIT License to This Repo
- [Pull Request 4](https://github.com/eosnetworkfoundation/devhub/pull/4) - package.json + README.md Updates
- [Pull Request 5](https://github.com/eosnetworkfoundation/devhub/pull/5) - Moar Documentation
- [Pull Request 6](https://github.com/eosnetworkfoundation/devhub/pull/6) - Rename BACKEND_API to DEVHUB_BACKEND_API in the Environment
- [Pull Request 7](https://github.com/eosnetworkfoundation/devhub/pull/7) - DevHub Frontend CICD Pipeline - Build Part 1
- [Pull Request 8](https://github.com/eosnetworkfoundation/devhub/pull/8) - DevHub Frontend CICD Pipeline - Build Part 2
- [Pull Request 9](https://github.com/eosnetworkfoundation/devhub/pull/9) - Authenticate to AWS Using OIDC in GitHub Actions
- [Pull Request 10](https://github.com/eosnetworkfoundation/devhub/pull/10) - Add Contextual AWS Deployment to GitHub Actions
- [Pull Request 11](https://github.com/eosnetworkfoundation/devhub/pull/11) - Fix Production AWS Deployment

