### PR TITLE
Authenticate to AWS Using OIDC in GitHub Actions

### DIFF
--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -45,6 +45,7 @@ jobs:
         with:
           aws-region: us-east-1
           role-to-assume: ${{ secrets.DEVHUB_FRONTEND_RO_IAM_ARN }}
+          role-duration-seconds: 300
 
       - name: Authentication Test
         run: aws s3 ls

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -1,6 +1,6 @@
 name: DevHub Frontend CICD
 
-on: [push, pull_request, workflow_dispatch]
+on: [push, workflow_dispatch]
 
 jobs:
   build:

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -42,8 +42,6 @@ jobs:
         with:
           aws-region: us-east-1
           role-to-assume: ${{ secrets.DEVHUB_FRONTEND_RO_IAM_ARN }}
-          role-session-name: OIDCSession
-          role-duration-seconds: 300
 
       - name: Authentication Test
         run: aws s3 ls

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -36,6 +36,9 @@ jobs:
     name: AWS Authentication
     runs-on: ubuntu-latest
     needs: build
+    permissions:
+      id-token: write
+      contents: read
     steps:
       - name: Authenticate to AWS
         uses: aws-actions/configure-aws-credentials@v1

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -31,3 +31,18 @@ jobs:
         with:
           name: dist-node-${{ matrix.node-version }}
           path: frontend/dist.tar.gz
+
+  aws:
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Authenticate to AWS
+        uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-region: us-east-1
+          role-to-assume: ${{ secrets.DEVHUB_FRONTEND_RO_IAM_ARN }}
+          role-session-name: OIDCSession
+          role-duration-seconds: 300
+
+      - name: Authentication Test
+        run: aws s3 ls

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -33,6 +33,7 @@ jobs:
           path: frontend/dist.tar.gz
 
   aws:
+    name: AWS Authentication
     runs-on: ubuntu-latest
     needs: build
     steps:

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -45,7 +45,7 @@ jobs:
         with:
           aws-region: us-east-1
           role-to-assume: ${{ secrets.DEVHUB_FRONTEND_RO_IAM_ARN }}
-          role-duration-seconds: 300
+          role-duration-seconds: 900
 
       - name: Authentication Test
         run: aws s3 ls

--- a/.github/workflows/frontend.yml
+++ b/.github/workflows/frontend.yml
@@ -41,7 +41,7 @@ jobs:
       contents: read
     steps:
       - name: Authenticate to AWS
-        uses: aws-actions/configure-aws-credentials@v1
+        uses: aws-actions/configure-aws-credentials@v1-node16
         with:
           aws-region: us-east-1
           role-to-assume: ${{ secrets.DEVHUB_FRONTEND_RO_IAM_ARN }}


### PR DESCRIPTION
From devrel [issue 135](https://github.com/eosnetworkfoundation/devrel/issues/135), this pull request adds steps to the CICD pipeline for the DevHub frontend that use the [OpenID Connect (OIDC) protocol](https://auth0.com/docs/authenticate/protocols/openid-connect-protocol) (OIDC) protocol to obtain a one-time token that authenticates GitHub Actions to Amazon Web Services. GitHub Actions is then able to temporarily "assume" an [IAM role](https://aws.amazon.com/iam) and perform an extremely narrow, predefined set of actions within the DevHub AWS account as if it had a user account and were logged in. The CICD system does what it is going to do, then the token is discarded at the conclusion of the GitHub Actions workflow.

The token expires in an extremely short (configurable) amount of time (15 minutes), so an attacker that were able to intercept this exchange or infiltrate GitHub Actions would have a narrow window of time to perform an attack. The token is random and unique for each and every GitHub Actions run. While the role that GitHub asks Amazon to use is currently stored in a repository secret, there is absolutely nothing sensitive about this value and obtaining it would not enable one to "assume" the IAM role or access our AWS account. With OIDC, there are zero credentials stored in the repository. The repository itself is the credential.


## See Also
- [Pull Request 1](https://github.com/eosnetworkfoundation/devhub/pull/1) - `.gitignore` Updates
- [Pull Request 2](https://github.com/eosnetworkfoundation/devhub/pull/2) - Pin nodeJS Toolchain
- [Pull Request 3](https://github.com/eosnetworkfoundation/devhub/pull/3) - Add the MIT License to This Repo
- [Pull Request 4](https://github.com/eosnetworkfoundation/devhub/pull/4) - `package.json` + `README.md` Updates
- [Pull Request 5](https://github.com/eosnetworkfoundation/devhub/pull/5) - Moar Documentation
- [Pull Request 6](https://github.com/eosnetworkfoundation/devhub/pull/6) - Rename `BACKEND_API` to `DEVHUB_BACKEND_API` in the Environment
- [Pull Request 7](https://github.com/eosnetworkfoundation/devhub/pull/7) - DevHub Frontend CICD Pipeline - Build Part 1
- [Pull Request 8](https://github.com/eosnetworkfoundation/devhub/pull/8) - DevHub Frontend CICD Pipeline - Build Part 2
- [Pull Request 9](https://github.com/eosnetworkfoundation/devhub/pull/9) - Authenticate to AWS Using OIDC in GitHub Actions
- [Pull Request 10](https://github.com/eosnetworkfoundation/devhub/pull/10) - Add Contextual AWS Deployment to GitHub Actions
- [Pull Request 11](https://github.com/eosnetworkfoundation/devhub/pull/11) - Fix Production AWS Deployment


